### PR TITLE
Default value set for role_id in migration

### DIFF
--- a/database/migrations/2016_04_28_100412_modify_user_add_role_foreign.php
+++ b/database/migrations/2016_04_28_100412_modify_user_add_role_foreign.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 class ModifyUserAddRoleForeign extends Migration {
     public function up() {
         Schema::table('users', function($table) {
-            $table->integer('role_id')->unsigned();
+            $table->integer('role_id')->unsigned()->default(-1);
             $table->foreign('role_id')
                     ->references('id')->on('roles');
         });

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -10,19 +10,19 @@ class UserSeeder extends Seeder {
         User::create(array(
                 'name' => 'admin',
                 'email' => 'FFE-Admin@mailinator.com',
-                'password' => 'pass',
+                'password' => Hash::make('pass'),
                 'role_id' => Role::where('name', '=', 'admin')->firstOrFail()->id
         ));
         User::create(array(
                 'name' => 'user1',
                 'email' => 'FFE-User1@mailinator.com',
-                'password' => 'pass',
+                'password' => Hash::make('pass'),
                 'role_id' => 2
         ));
         User::create(array(
                 'name' => 'user2',
                 'email' => 'FFE-User2@mailinator.com',
-                'password' => 'pass',
+                'password' => Hash::make('pass'),
                 'role_id' => 3
         ));
     }


### PR DESCRIPTION
This fixes a bug with sqlite, and adds hashing to seeder user passwords
