### PR TITLE
bug fix to accounts view page

### DIFF
--- a/resources/views/accounts/accounts.blade.php
+++ b/resources/views/accounts/accounts.blade.php
@@ -5,7 +5,7 @@
 <?php
 	$contents = $contents->accounts;
 	$columns = ['ID', 'Parent ID', 'Name', 'Address', 'Invoice Interval', 'Start Date'];
-	$variables = [['account', 'account_id'], ['account', 'parent_account_id'], ['account', 'name'], 'address'];//, 'id', 'name', 'address','contact_name'];
+	$variables = [['account', 'account_id'], ['account', 'parent_account_id'], ['account', 'name'], 'address', ['account', 'invoice_interval'], ['account', 'start_date']];
 ?>
 
 @endsection


### PR DESCRIPTION
$columns and $variables must be of the same length, or the table will break 